### PR TITLE
Fixed typo in StackTrace

### DIFF
--- a/Trx2Excel/ExcelUtils/ExcelWriter.cs
+++ b/Trx2Excel/ExcelUtils/ExcelWriter.cs
@@ -77,7 +77,7 @@ namespace Trx2Excel.ExcelUtils
                     Color.Red :
                     Color.ForestGreen);
                 sheet.Cells[i, 4].Value = result.Message;
-                sheet.Cells[i, 5].Value = result.StrackTrace;
+                sheet.Cells[i, 5].Value = result.StackTrace;
                 i++;
             }
         }

--- a/Trx2Excel/Model/UnitTestResult.cs
+++ b/Trx2Excel/Model/UnitTestResult.cs
@@ -11,8 +11,7 @@ namespace Trx2Excel.Model
         public string TestName { get; set; }
         public string Outcome { get; set; }
         public string Message { get; set; }
-        public string StrackTrace { get; set; }
+        public string StackTrace { get; set; }
         public string NameSpace { get; set; }
-
     }
 }

--- a/Trx2Excel/TrxReaderUtil/TrxReader.cs
+++ b/Trx2Excel/TrxReaderUtil/TrxReader.cs
@@ -50,7 +50,7 @@ namespace Trx2Excel.TrxReaderUtil
                     var output = node.ChildNodes[GetNodeIndex(node, NodeName.Output)];
                     var errorInfo = output.ChildNodes[GetNodeIndex(output, NodeName.ErrorInfo)];
                     result.Message = errorInfo.ChildNodes[GetNodeIndex(errorInfo, NodeName.Message)]?.InnerText;
-                    result.StrackTrace = errorInfo.ChildNodes[GetNodeIndex(node, NodeName.StackTrace)]?.InnerText;
+                    result.StackTrace = errorInfo.ChildNodes[GetNodeIndex(node, NodeName.StackTrace)]?.InnerText;
                     FailCount++;
                     break;
                 case TestOutcome.Passed:


### PR DESCRIPTION
There was a typo in the StackTrace property of UnitTestResults. I fixed it so it is spelled correctly. 